### PR TITLE
Add Docker environment & web demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The current version releases the sampling code, while the detailed training code
 This 
 [Google Colab notebook](https://colab.research.google.com/drive/1fQI8OgzMAR0bquCrvhlAtXSw6iMFbVgI) allows for sampling from the CodeGen models (contributed by @Penguin-jpg).
 
+<a href="https://replicate.com/salesforce/codegen"><img src="https://replicate.com/salesforce/codegen/badge"></a> also provides a demo.
+
 
 
 ## Setup

--- a/cog.yaml
+++ b/cog.yaml
@@ -1,0 +1,31 @@
+# Configuration for Cog ⚙️
+# Reference: https://github.com/replicate/cog/blob/main/docs/yaml.md
+
+image: "r8.im/salesforce/codegen"
+build:
+  # set to true if your model requires a GPU
+  gpu: true
+
+  # a list of ubuntu apt packages to install
+  # system_packages:
+    # - "libgl1-mesa-glx"
+    # - "libglib2.0-0"
+
+  # python version in the form '3.8' or '3.8.12'
+  python_version: "3.8"
+
+  # a list of packages in the format <package-name>==<version>
+  python_packages:
+    - "torch==1.9.0"
+    - "transformers==4.16.2"
+  
+  # commands run after the environment is setup
+  # maybe try installing huggingface stuff w python manually here
+
+  run: 
+    # run a huggingface import via python, so it is guaranteed to be in the image rather than downloaded at runtime.
+    - python3.8 -m pip install transformers && python3.8 -c 'from transformers import GPT2TokenizerFast; t = GPT2TokenizerFast.from_pretrained("gpt2"); print(t.vocab_size)'
+
+
+# predict.py defines how predictions are run on your model
+predict: "predict.py:Predictor"

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,86 @@
+import os
+import tempfile
+
+import torch
+import cog
+from cog import BasePredictor, Input
+from torch import inference_mode
+from torch.cuda.amp import autocast
+
+from jaxformer.hf.codegen.modeling_codegen import CodeGenForCausalLM
+from jaxformer.hf.sample import (create_custom_gpt2_tokenizer, print_time,
+                                 sample, set_env, set_seed, truncate)
+
+DEFAULT_CONTEXT = "# approximate pi using the monte carlo method \ndef calculate_pi():"
+
+
+class Predictor(BasePredictor):
+    def setup(self):
+        """Load the model into memory to make running multiple predictions efficient"""
+        self.model_name = "codegen-2B-mono"
+        ckpt = f"./checkpoints/{self.model_name}"
+        assert os.path.isdir(ckpt), f"Model directory {ckpt} does not exist"
+
+        self.device = torch.device("cuda")
+
+        with print_time("loading parameters"):
+            self.model = CodeGenForCausalLM.from_pretrained(
+                ckpt,
+                revision="float16",
+                torch_dtype=torch.float16,
+                low_cpu_mem_usage=True,
+            )
+            self.model.to(self.device)
+
+        with print_time("loading tokenizer"):
+            self.tokenizer = create_custom_gpt2_tokenizer()
+            self.tokenizer.padding_side = "left"
+            self.pad = 50256
+            self.tokenizer.pad_token = self.pad
+
+    @autocast()
+    @inference_mode()
+    def predict(
+        self,
+        context: str = Input(
+            description="Some starting python code. CodeGen will try to complete the code provided, up to the max_length.",
+            default=DEFAULT_CONTEXT,
+        ),
+        rng_seed: int = Input(description="Random number generator seed", default=0),
+        rng_deterministic: bool = Input(description="Deterministic RNG", default=True),
+        top_p: float = Input(
+            description="Top-p sampling probability.", ge=0, le=1, default=0.95
+        ),
+        temperature: float = Input(
+            description="Temperature for sampling", ge=0, le=1, default=0.2
+        ),
+        max_length: int = Input(
+            description="Maximum length of generated text", ge=0, le=1000, default=128
+        ),
+        batch_size: int = Input(description="Batch size", ge=1, le=10, default=1),
+    ) -> cog.Path:
+        """Run a single prediction on the model"""
+        set_env()
+        set_seed(rng_seed, deterministic=rng_deterministic)
+
+        with print_time("sampling"):
+            completion = sample(
+                device=self.device,
+                model=self.model,
+                tokenizer=self.tokenizer,
+                context=context,
+                pad_token_id=self.pad,
+                num_return_sequences=batch_size,
+                temp=temperature,
+                top_p=top_p,
+                max_length_sample=max_length,
+            )[0]
+            truncation = truncate(completion)
+
+        # cog handles markdown files with the `.md` extension, 
+        # so we need to write the output to a file inside after wrapping in a md code block.
+        out_path = cog.Path(tempfile.mkdtemp()) / "codegen_prediction.md"
+        output_as_markdown = f"```python\n{context}{truncation}\n```"
+        with open(out_path, "w") as f:
+            f.write(output_as_markdown)
+        return out_path

--- a/predict.py
+++ b/predict.py
@@ -57,7 +57,6 @@ class Predictor(BasePredictor):
         max_length: int = Input(
             description="Maximum length of generated text", ge=0, le=1000, default=128
         ),
-        batch_size: int = Input(description="Batch size", ge=1, le=10, default=1),
     ) -> cog.Path:
         """Run a single prediction on the model"""
         set_env()
@@ -70,7 +69,7 @@ class Predictor(BasePredictor):
                 tokenizer=self.tokenizer,
                 context=context,
                 pad_token_id=self.pad,
-                num_return_sequences=batch_size,
+                num_return_sequences=1,
                 temp=temperature,
                 top_p=top_p,
                 max_length_sample=max_length,


### PR DESCRIPTION
Hey! I'm Clay from replicate.com. Really exciting model - thanks so much for releasing the weights! Hopefully this sort of tech can be a little more accessible to those without the means to use OpenAI's API. 

I added support for `cog` so that others can dockerize and serve this themselves. Further, people should be able to run on replicate using the deployed container. 

[Claim your page here](https://replicate.com/salesforce/codegen) so you can edit it, and we'll feature it on our website and tweet about it too.

Thanks - and let me know if the PR needs any changes.